### PR TITLE
Fix 'Could not find a storyboard named 'QBImagePicker' in bundle NSBu…

### DIFF
--- a/QBImagePicker/QBImagePickerController.m
+++ b/QBImagePicker/QBImagePickerController.m
@@ -42,7 +42,7 @@
         _selectedAssets = [NSMutableOrderedSet orderedSet];
         
         // Get asset bundle
-        self.assetBundle = [NSBundle bundleForClass:[self class]];
+        self.assetBundle = [NSBundle bundleForClass:[QBImagePickerController class]];
         NSString *bundlePath = [self.assetBundle pathForResource:@"QBImagePicker" ofType:@"bundle"];
         if (bundlePath) {
             self.assetBundle = [NSBundle bundleWithPath:bundlePath];


### PR DESCRIPTION
…ndle'

cocoapods で use_frameworks! を指定した場合かつ、 QBImagePickerController を継承した
クラスをアプリで使っている場合に上記エラーが発生してクラッシュしました。

この時、 self がアプリ側で継承しているクラスになってしまうため
`[NSBundle bundleForClass:[self class]];` で取得できる Bundle は
アプリ側のものとなり Frameworks ディレクトリ内にある QBImagePickerController
の bundle を取得できずにクラッシュが発生してしまいます。

補足:

use_frameworks! を使わない場合 QBImagePickerController の bundle は
アプリの root ディレクトリに配置されますが、使用した場合は Frameworks 内に
配置されます。
